### PR TITLE
flickr API will require HTTPS soon

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -23,7 +23,7 @@ $(function(){
   });
 
   // flickr
-  var url = 'http://api.flickr.com/services/rest/?format=json&method=flickr.photos.search&api_key=5b1e087229399735670b25418d55dd0f&user_id=58435337@N05&callback=?';
+  var url = 'https://api.flickr.com/services/rest/?format=json&method=flickr.photos.search&api_key=5b1e087229399735670b25418d55dd0f&user_id=58435337@N05&callback=?';
 
   $.getJSON(url);
 


### PR DESCRIPTION
For more information:
https://code.flickr.net/2014/04/30/flickr-api-going-ssl-only-on-june-27th-2014/
