### PR TITLE
Improve header

### DIFF
--- a/donate.html
+++ b/donate.html
@@ -13,7 +13,7 @@
     <div id="branding" role="banner">
       <a href="./index.html"><h1 id="logo">Skullspace</h1></a>
       <ul id="main-nav">
-        <li><a href="./calendar/" >Calendar</a></li>
+        <li><a href="http://www.skullspace.ca/calendar/" >Calendar</a></li>
         <li><a href="http://wiki.skullspace.ca/" >Wiki</a></li>
         <li><a href="https://www.facebook.com/skullspacewpg" >Facebook</a></li>
         <li><a href="https://twitter.com/skullspacewpg" >Twitter</a></li>

--- a/donate.html
+++ b/donate.html
@@ -10,19 +10,20 @@
     <script src="http://maps.google.com/maps/api/js?sensor=true"></script>
   </head>
   <body>
-    <a href="http://github.com/skullspace/skullspace.ca"><img style="position: absolute; top: 0; right: 0; border: 0;" src="fork_ribbon.png" alt="Fork me on GitHub"></a>
     <div id="branding" role="banner">
       <h1 id="logo">Skullspace</h1>
       <ul id="main-nav">
-        <li><a href="http://www.skullspace.ca/calendar/" >Calendar</a></li>
+        <li><a href="./calendar/" >Calendar</a></li>
         <li><a href="http://wiki.skullspace.ca/" >Wiki</a></li>
         <li><a href="https://www.facebook.com/skullspacewpg" >Facebook</a></li>
         <li><a href="https://twitter.com/skullspacewpg" >Twitter</a></li>
         <li><a href="https://github.com/skullspace"  >Code</a></li>
-        <li><a href="http://www.skullspace.ca/donate.html">Donate</a></li>
+        <li><a href="./donate.html">Donate</a></li>
         <li><a href="http://www.skullspace.ca/wiki/index.php/Category:Required_Reading">FAQ</a></li>
         <li><a href="mailto:info@skullspace.ca">Contact Us</a></li>
+        <li><a href="./workshops/index.html">Workshops</a></li>
       </ul>
+      <a href="http://github.com/skullspace/skullspace.ca"><img id="forkImage" src="fork_ribbon.png" alt="Fork me on GitHub"></a>
       <br class="clear"/>
     </div>
     <div class="wrapper">

--- a/donate.html
+++ b/donate.html
@@ -11,7 +11,7 @@
   </head>
   <body>
     <div id="branding" role="banner">
-      <h1 id="logo">Skullspace</h1>
+      <a href="./index.html"><h1 id="logo">Skullspace</h1></a>
       <ul id="main-nav">
         <li><a href="./calendar/" >Calendar</a></li>
         <li><a href="http://wiki.skullspace.ca/" >Wiki</a></li>

--- a/index.html
+++ b/index.html
@@ -11,9 +11,8 @@
     <script src="http://maps.google.com/maps/api/js?sensor=true"></script>
   </head>
   <body>
-    
     <div id="branding" role="banner">
-      <h1 id="logo">Skullspace</h1>
+      <a href="./index.html"><h1 id="logo">Skullspace</h1></a>
       <ul id="main-nav">
         <li><a href="./calendar/" >Calendar</a></li>
         <li><a href="http://wiki.skullspace.ca/" >Wiki</a></li>

--- a/index.html
+++ b/index.html
@@ -15,15 +15,15 @@
     <div id="branding" role="banner">
       <h1 id="logo">Skullspace</h1>
       <ul id="main-nav">
-        <li><a href="http://www.skullspace.ca/calendar/" >Calendar</a></li>
+        <li><a href="./calendar/" >Calendar</a></li>
         <li><a href="http://wiki.skullspace.ca/" >Wiki</a></li>
         <li><a href="https://www.facebook.com/skullspacewpg" >Facebook</a></li>
         <li><a href="https://twitter.com/skullspacewpg" >Twitter</a></li>
         <li><a href="https://github.com/skullspace"  >Code</a></li>
-        <li><a href="http://www.skullspace.ca/donate.html">Donate</a></li>
+        <li><a href="./donate.html">Donate</a></li>
         <li><a href="http://www.skullspace.ca/wiki/index.php/Category:Required_Reading">FAQ</a></li>
         <li><a href="mailto:info@skullspace.ca">Contact Us</a></li>
-        <li><a href="http://www.skullspace.ca/workshops">Workshops</a></li>
+        <li><a href="./workshops/index.html">Workshops</a></li>
       </ul>
       <a href="http://github.com/skullspace/skullspace.ca"><img id="forkImage" src="fork_ribbon.png" alt="Fork me on GitHub"></a>
       <br class="clear"/>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <script src="http://maps.google.com/maps/api/js?sensor=true"></script>
   </head>
   <body>
-    <a href="http://github.com/skullspace/skullspace.ca"><img style="position: absolute; top: 0; right: 0; border: 0;" src="fork_ribbon.png" alt="Fork me on GitHub"></a>
+    
     <div id="branding" role="banner">
       <h1 id="logo">Skullspace</h1>
       <ul id="main-nav">
@@ -25,6 +25,7 @@
         <li><a href="mailto:info@skullspace.ca">Contact Us</a></li>
         <li><a href="http://www.skullspace.ca/workshops">Workshops</a></li>
       </ul>
+      <a href="http://github.com/skullspace/skullspace.ca"><img id="forkImage" src="fork_ribbon.png" alt="Fork me on GitHub"></a>
       <br class="clear"/>
     </div>
     <div class="wrapper">

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     <div id="branding" role="banner">
       <a href="./index.html"><h1 id="logo">Skullspace</h1></a>
       <ul id="main-nav">
-        <li><a href="./calendar/" >Calendar</a></li>
+        <li><a href="http://www.skullspace.ca/calendar/" >Calendar</a></li>
         <li><a href="http://wiki.skullspace.ca/" >Wiki</a></li>
         <li><a href="https://www.facebook.com/skullspacewpg" >Facebook</a></li>
         <li><a href="https://twitter.com/skullspacewpg" >Twitter</a></li>

--- a/style.css
+++ b/style.css
@@ -148,6 +148,19 @@ h1#logo{
   color: black;
 }
 
+#forkImage{
+  position: absolute; 
+  top: 0; 
+  right: 0; 
+  border: 0;
+  margin-top: -10px;
+  margin-right:-20px;
+}
+
+#branding{
+  position:relative;
+}
+
 #twitter_feed{
   width: 290px;
   float: left;


### PR DESCRIPTION
Minor improvements to the top header of the site.

The "Fork me on GitHub" image is now stuck to the top right corner of the banner at all times now instead of moving with the page resizing.

I made the links relative so that it is easier to see changes in development.

And I made the SkullSpace banner image a link to the homepage.